### PR TITLE
Fix map generation

### DIFF
--- a/stars_analytics.py
+++ b/stars_analytics.py
@@ -284,10 +284,9 @@ def print_stars_per_country(fcache):
 
 def plot_stars_per_country(fcache):
     df = cached_query_results_df(fcache)
-    plt.figure(figsize=(20,10))
-    #df['% extrapolated'].plot(kind='bar');
+    plt.figure(figsize=(20, 10))
     plt.bar(df['Country'], df['% extrapolated'], width = 1/1.5)
-    #plt.title('New stars activity for ' + start_of_month.strftime("%B/%Y"))
+    plt.title('Stars Per Country (%)')
     plt.xticks(rotation=90)
     plt.ylabel('% Stars');
     plt.show()
@@ -320,7 +319,7 @@ def create_stars_map(fcache, html_name='stars_map.html'):
     countries_list, record_count, total_matches = cached_query_results_summary(fcache)
 
     # Make an empty map
-    m = folium.Map(location=[20, 0], tiles="Mapbox Bright", zoom_start=2)
+    m = folium.Map(location=[20, 0], tiles='Cartodb Positron', zoom_start=3)
 
     MAX_RADIUS = 3000000
 


### PR DESCRIPTION
Creating maps with folium-mapbox is no longer supported, so changed to a
different map (looks similar enough to mapbox)
Using folium with mapbox maps now requires an authentication token.
See failure here: https://python-graph-gallery.com/313-bubble-map-with-folium/
See similar issue reported here: https://github.com/python-visualization/folium/issues/922